### PR TITLE
fix: modifies addRelations to store on child, not arrow

### DIFF
--- a/src/converter.ts
+++ b/src/converter.ts
@@ -223,14 +223,14 @@ class MuralDB extends Nedb{
 
             //update by adding parents but only in the selected DB
             const relationPromises = arrows.map(async (a)=>{
-                const query = {_id:a._id};
-                const set = {$set:{[parentField]:a.startRefId}}
-                const options = {multi:false,returnUpdatedDocs:true }
-                if(modifyOriginal && a.startRefId){
+                const query = {id:a.startRefId};
+                const set = {$set:{[parentField]:a.endRefId}}
+                const options = {multi:false, returnUpdatedDocs:true }
+                if(modifyOriginal && a.startRefId && a.endRefId){
                     await this.updateAsync.apply(this,[query,set, options])
                 }
                 return this.updateAsync.apply(this.cacheDb,[query,set, options])
-                    .then(r=>r.affectedDocuments);                 
+                    .then(r=>r.affectedDocuments);   
   
             })
             await Promise.all(relationPromises)

--- a/test/converter.test.ts
+++ b/test/converter.test.ts
@@ -206,18 +206,25 @@ describe('converter', () => {
     
     it('add Relations', async function (){
         this.timeout(10000);
-        const data = getData()
         const con = new Converter() 
-        await con.insertAsync(data)
-        const results1 = await con.addRelations()
-        assert.strictEqual(results1.length,700)
-        const results2 = await con.findAsync(
-            {"$or":[
-                {'arrowParent' : {'$exists': true}}
-            ]}
-        ).sort({arrowParent:1})
-        assert.strictEqual(results2.length,223)
-        assert.strictEqual(results2[0].arrowParent,'0-1667868664111')
+        await con.insertAsync([
+            {
+                "id": "parent",
+            },
+            {
+                "id":"arrow",
+                "arrowType": "straight",
+                "endRefId": "parent",
+                "startRefId": "child", 
+                "tip": "single",
+                "type": "arrow"
+            },
+            {
+                "id": "child",
+            },
+        ])
+        const results1 = await con.addRelations().asCursor().sort({id:1}) as unknown as any
+        assert.strictEqual(results1[1].arrowParent,'parent')
     });
     
 


### PR DESCRIPTION
# Description

This fixes a mistake in the addRelations logic that added the relation to the arrow instead of the child.  This modifes both the test and logic.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] New test creates three widgets and the arrow relationship and validates that they are sorted and connected

# Checklist:

- [x] My code follows the [contribution and style guidelines](./.github/contributing.md) of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules


Thanks for contributing! ❤️

